### PR TITLE
Rename CourtPro references to SlotSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CourtPro Updates Server
+# SlotSet Updates Server
 
 This repository hosts static update files for [Expo](https://expo.dev/) apps. Use it to deliver over‑the‑air updates built with `expo export`.
 
@@ -21,7 +21,7 @@ Set the `updates.url` field in `app.json` or `app.config.ts` to your GitHub Page
 ```json
 {
   "updates": {
-    "url": "https://<user>.github.io/courtpro-updates"
+    "url": "https://<user>.github.io/slotset-updates"
   }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "courtpro-updates",
+  "name": "slotset-updates",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "courtpro-updates",
+      "name": "slotset-updates",
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "courtpro-updates",
+  "name": "slotset-updates",
   "version": "1.0.0",
   "description": "Static hosting for Expo update bundles",
   "scripts": {

--- a/public/index.html
+++ b/public/index.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>CourtPro Updates</title>
+  <title>SlotSet Updates</title>
 </head>
 <body>
-  <h1>CourtPro Updates Server</h1>
+  <h1>SlotSet Updates Server</h1>
   <p>Upload update files generated with <code>expo export</code> into this folder.</p>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rename CourtPro references to SlotSet across docs and config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c1e6851fc832595d18d63c8c5f91e